### PR TITLE
chore(ci): add cargo deny check to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,10 +108,21 @@ jobs:
           override: true
 
       # Install and run cargo udeps to find unused cargo dependencies
-      - name: cargo-udeps duplicate dependency check
+      - name: cargo-udeps unused dependency check
         run: |
           cargo install cargo-udeps --locked
           cargo +nightly udeps --all-targets
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # wget the shared deny.toml file from the QA repo
+    - shell: bash
+      run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
+
+    - uses: EmbarkStudios/cargo-deny-action@v1
 
   test:
     name: Test


### PR DESCRIPTION
This fetches a shared deny.toml from the QA repo before running the cargo deny GH Action.