### PR TITLE
chore: use deny(warnings) instead of forbid(warnings)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,10 +36,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,10 +29,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
@@ -63,10 +59,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build
@@ -139,10 +131,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     deprecated,
@@ -43,7 +42,8 @@
     unused_comparisons,
     unused_features,
     unused_parens,
-    while_true
+    while_true,
+    warnings
 )]
 #![warn(
     trivial_casts,


### PR DESCRIPTION
`deny` can be overriden with `allow`, unlike `forbid`. This allows us to `allow` some warnings on a case-by-case basis which is especially useful in macros. Without this, some macros from other crates caused compilation errors on nightly, however it's possible it would eventually affect stable as well.